### PR TITLE
Adding reset method to Registry

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -26,11 +26,6 @@ parameters:
 			path: src/DependencyInjection/Configuration.php
 
 		-
-			message: "#^Property DiabloMedia\\\\Bundle\\\\Doctrine1Bundle\\\\Registry\\:\\:\\$connections is never read, only written\\.$#"
-			count: 1
-			path: src/Registry.php
-
-		-
 			message: "#^Property DiabloMedia\\\\Bundle\\\\Doctrine1Bundle\\\\Registry\\:\\:\\$defaultConnection is never read, only written\\.$#"
 			count: 1
 			path: src/Registry.php

--- a/src/Registry.php
+++ b/src/Registry.php
@@ -33,4 +33,11 @@ class Registry
     {
         return $this->container->get('doctrine1.' . $name . '_connection');
     }
+
+    public function reset(): void
+    {
+        foreach ($this->connections as $connection) {
+            $connection->clear();
+        }
+    }
 }

--- a/src/Registry.php
+++ b/src/Registry.php
@@ -3,6 +3,7 @@
 namespace DiabloMedia\Bundle\Doctrine1Bundle;
 
 use Doctrine_Connection;
+use Doctrine_Manager;
 use Psr\Container\ContainerInterface;
 
 class Registry
@@ -36,7 +37,11 @@ class Registry
 
     public function reset(): void
     {
-        foreach ($this->connections as $connection) {
+        $manager = Doctrine_Manager::getInstance();
+        foreach ($this->connections as $connectionName) {
+            // Connection names come in as "doctrine1.name_connection", we want "name"
+            $connectionName = preg_replace('|_connection$|', '', substr($connectionName, 10));
+            $connection     = $manager->getConnection($connectionName);
             $connection->clear();
         }
     }

--- a/src/Registry.php
+++ b/src/Registry.php
@@ -41,8 +41,10 @@ class Registry
         foreach ($this->connections as $connectionName) {
             // Connection names come in as "doctrine1.name_connection", we want "name"
             $connectionName = preg_replace('|_connection$|', '', substr($connectionName, 10));
-            $connection     = $manager->getConnection($connectionName);
-            $connection->clear();
+            if ($connectionName !== null) {
+                $connection = $manager->getConnection($connectionName);
+                $connection->clear();
+            }
         }
     }
 }


### PR DESCRIPTION
This is needed when using this bundle with tests, as Symfony will call the `reset` method on the Registry class at the end of a test run.